### PR TITLE
Import Keyring backed password storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Simply run:
 
     $ pip install git+https://github.com/piontas/python-aada.git
 
+In order to install with keyring for password management:
+
+    $ pip install "git+https://github.com/piontas/python-aada.git#egg=python-aada [keyring]"
 
 # Usage
 

--- a/aada/__init__.py
+++ b/aada/__init__.py
@@ -1,5 +1,12 @@
 __version__ = "0.1.6"
 
+try:
+    import keyring
+except ImportError:
+    KEYRING = False
+else:
+    KEYRING = True
+
 LOGIN_URL = 'https://login.microsoftonline.com'
 MFA_WAIT_METHODS = ('PhoneAppNotification', 'TwoWayVoiceMobile')
 MFA_ALLOWED_METHODS = ('PhoneAppOTP', 'OneWaySMS') + MFA_WAIT_METHODS

--- a/aada/__init__.py
+++ b/aada/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.1.6"
 
 try:
-    import keyring
+    import keyring  # noqa
 except ImportError:
     KEYRING = False
 else:

--- a/aada/configure.py
+++ b/aada/configure.py
@@ -15,7 +15,7 @@ class Configure:
         ('azure_tenant_id', 'Azure tenant id'),
         ('azure_app_id_uri', 'Azure app id uri'),
         ('azure_username', 'Azure username'),
-        ('use_keyring', 'Use Keyring to store password if available'),
+        ('use_keyring', 'Use Keyring to store password if available (true/false)'),
         ('azure_mfa', 'If Azure MFA enabled: {:}'.format(', '.join(
             MFA_ALLOWED_METHODS))),
         ('session_duration', 'AWS CLI session duration'),

--- a/aada/login.py
+++ b/aada/login.py
@@ -201,8 +201,7 @@ class Login:
         aws_roles = []
         for attribute in ET.fromstring(base64.b64decode(saml_response)).iter(
                 '{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
-            if (attribute.get('Name') ==
-                    'https://aws.amazon.com/SAML/Attributes/Role'):
+            if (attribute.get('Name') == 'https://aws.amazon.com/SAML/Attributes/Role'):
                 for value in attribute.iter(
                         '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'):
                     aws_roles.append(value.text)

--- a/aada/login.py
+++ b/aada/login.py
@@ -266,7 +266,7 @@ class Login:
         """
         url = self._build_saml_login_url()
         username_input = self._azure_username
-        keyring_pass = None
+        kr_pass = None
         print('Azure username: {}'.format(self._azure_username))
 
         if KEYRING and self._use_keyring:

--- a/aada/login.py
+++ b/aada/login.py
@@ -15,8 +15,11 @@ from urllib.parse import quote, parse_qs
 from awscli.customizations.configure.writer import ConfigFileWriter
 from pyppeteer.errors import BrowserError, TimeoutError, NetworkError
 
-from . import LOGIN_URL, MFA_WAIT_METHODS
+from . import KEYRING, LOGIN_URL, MFA_WAIT_METHODS
 from .launcher import launch
+
+if KEYRING:
+    import keyring
 
 
 class MfaException(Exception):
@@ -67,7 +70,9 @@ class Login:
         self._azure_mfa = self._config.get('azure_mfa')
         self._azure_kmsi = self._config.get('azure_kmsi', False)
         self._azure_username = self._config.get('azure_username')
+        self._azure_password = None
         self._session_duration = int(self._config.get('session_duration', 3600))
+        self._use_keyring = self._config.get('use_keyring')
         self.saml_response = None
 
         if saml_request:
@@ -261,8 +266,20 @@ class Login:
         """
         url = self._build_saml_login_url()
         username_input = self._azure_username
+        keyring_pass = None
         print('Azure username: {}'.format(self._azure_username))
-        password_input = getpass.getpass('Azure password: ')
+
+        if KEYRING and self._use_keyring:
+            try:
+                print('Getting password from keyring')
+                kr_pass = keyring.get_password('aada', self._azure_username)
+            except Exception as e:
+                print('Failed getting password from Keyring {}'.format(e))
+
+        if kr_pass is not None:
+            password_input = kr_pass
+        else:
+            password_input = getpass.getpass('Azure password: ')
 
         asyncio.get_event_loop().run_until_complete(self._render_js_form(
             url, username_input, password_input, self._azure_mfa))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ boto3
 websockets==6.0
 pyee==5.0.0
 pyppeteer==0.0.19
+keyring~=18.0.0

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=dependencies,
+    extras_require = {
+        'keyring':  ['keyring~=18.0.0']
+    }
     entry_points={
         'console_scripts': [
             'aada = aada.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=dependencies,
     extras_require = {
         'keyring':  ['keyring~=18.0.0']
-    }
+    },
     entry_points={
         'console_scripts': [
             'aada = aada.cli:main',


### PR DESCRIPTION
Initial attempt at supporting storing the password via keyring. 
Note: the conditional import is to avoid requiring installing keyring, I felt that was unecessary to add as a strict dependency.
Tested this on OSX (Mojave) and Windows (VDI).
On OSX the first time keyring access is required, the user will need to authenticate python to use the Keychain, on Windows, an active logged in user has access to hers/his own Credential store.