### PR TITLE
Downgrade websockets to v6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests
 awscli
 botocore
 boto3
-websockets==7.0
+websockets~=6.0
 pyee==6.0.0
 pyppeteer==0.0.25
 keyring~=18.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 dependencies = [
-    'awscli', 'botocore', 'boto3', 'requests', 'websockets==7.0',
+    'awscli', 'botocore', 'boto3', 'requests', 'websockets~=6.0',
     'pyppeteer==0.0.25'
 ]
 


### PR DESCRIPTION
This should fix the sporadic errors with the following message:

    pyppeteer.errors.NetworkError: Protocol error Target.activateTarget: Target closed.