### PR TITLE
Improving keyring setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simply run:
 
 In order to install with keyring for password management:
 
-    $ pip install "git+https://github.com/piontas/python-aada.git#egg=python-aada [keyring]"
+    $ pip install "git+https://github.com/piontas/python-aada.git#egg=aada [keyring]"
 
 # Usage
 

--- a/aada/configure.py
+++ b/aada/configure.py
@@ -52,7 +52,7 @@ class Configure:
         config_filename = os.path.expanduser(
             self._session.get_config_variable('config_file'))
         if KEYRING and config.get('use_keyring'):
-            updatepwd = input('Update Azure password in keyring? ')
+            updatepwd = input('Update Azure password in keyring? (yes/no)')
             if updatepwd.upper() in ['Y', 'YES']:
                 azure_pass = getpass.getpass('Azure password ')
                 keyring.set_password('aada', config.get('azure_username'),


### PR DESCRIPTION
Small error on readme (egg=aada) needed correction
When setting up, I typed "true" given the question "Update Azure password in keyring?", turns out I should have typed "yes". Making that clearer.