### PR TITLE
Fix pyee dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 dependencies = [
     'awscli', 'botocore', 'boto3', 'requests', 'websockets~=6.0',
-    'pyppeteer==0.0.25'
+    'pyppeteer==0.0.25', 'pyee==6.0.0'
 ]
 
 setup(


### PR DESCRIPTION
Currently, by default, version 8 will be installed of pyee. It will
not work, because of asyncio port. Requirements.txt already have pined
the dependency so we can do the same in setup.py.